### PR TITLE
Swaps `master` for `main` in action config

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: CD
 on:
   push:
     branches:
-      - master
+      - main
       - next
       - next-major
       - alpha


### PR DESCRIPTION
Defaults to `master`, I forgot to switch it out.