### PR TITLE
Disable prop types rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -76,7 +76,7 @@ module.exports = {
     '@typescript-eslint/no-non-null-asserted-optional-chain': 'warn', // TODO MUST FIX
 
     'react/jsx-props-no-spreading': 'warn',
-    'react/prop-types': 'warn', // TODO will be fixed after TS migration
+    'react/prop-types': 'off',
     'react/display-name': 'warn', // TODO easy fix
 
     // mimic default eslint


### PR DESCRIPTION
We don't use prop-types and it adds no value at all just creates a visual noise for developers.

Also it spams with lots of warning when you run `yarn lint` so you can easily miss the important things.

We have no plans of using prop-types. 

So this rule makes no sense.